### PR TITLE
Fixed bug: now sets TTL correctly to 0 in rearm.

### DIFF
--- a/src/vmod_softpurge.c
+++ b/src/vmod_softpurge.c
@@ -84,7 +84,7 @@ vmod_softpurge(const struct vrt_ctx *ctx)
 
 		// Update the object's TTL so that it expires right now.
 		if (o->exp.ttl > (now - o->exp.t_origin))
-			EXP_Rearm(o, now, now - o->exp.t_origin, o->exp.grace, o->exp.keep);
+			EXP_Rearm(o, now, 0.0, o->exp.grace, o->exp.keep);
 
 		VSL(SLT_Debug, 0, "XX: object updated. ttl ends in %.3f, grace ends in %.3f for object %i",
 		    (EXP_Ttl(ctx->req, o) - now),


### PR DESCRIPTION
The rearm was incorrectly set to a TTL of (now - o->exp.t_origin) which equals the Age of the object. As a result the object remained valid for the same amount of time as it's Age at the time of the softpurge.

I think this was overlooked because when you do a softpurge almost immediately after fetching the object, it's Age is still small, and the expire will happen in a short time.

However, when you softpurge at a time the object is already almost expiring, the object will stay valid even longer. For example:

* Object has TTL = 120s
* Softpurge is done 110s after object was loaded in cache.
* Rearm is done with TTL = 110s, resulting in the object staying in cache for another 110s.

This fix solves this issue.